### PR TITLE
SH-35: Rework validation errors to return an object instead of an array

### DIFF
--- a/internal/appvalidator/appvalidator.go
+++ b/internal/appvalidator/appvalidator.go
@@ -12,10 +12,7 @@ type AppValidator struct {
 	validate *validator.Validate
 }
 
-type ValidationError struct {
-	Field   string `json:"field"`
-	Message string `json:"message"`
-}
+type ValidationError map[string]string
 
 func New() *AppValidator {
 	validate := validator.New(validator.WithRequiredStructEnabled())
@@ -45,15 +42,16 @@ func (av *AppValidator) Validate(i any) error {
 	return nil
 }
 
-func (av *AppValidator) FormatErrors(err error) []ValidationError {
-	var validationErrors []ValidationError
+func (av *AppValidator) FormatErrors(err error) ValidationError {
+	validationErrors := make(ValidationError)
 
 	if validationErrs, ok := err.(validator.ValidationErrors); ok {
 		for _, e := range validationErrs {
-			validationErrors = append(validationErrors, ValidationError{
-				Field:   av.getFieldName(e),
-				Message: av.getErrorMessage(e),
-			})
+			field := av.getFieldName(e)
+			if validationErrors[field] != "" {
+				continue
+			}
+			validationErrors[field] = av.getErrorMessage(e)
 		}
 	}
 

--- a/internal/appvalidator/appvalidator_test.go
+++ b/internal/appvalidator/appvalidator_test.go
@@ -31,12 +31,10 @@ func TestValidateShortCode(t *testing.T) {
 			errors := validate.FormatErrors(err)
 			if tt.expected {
 				assert.NoError(t, err)
-				assert.Len(t, errors, 0, "got no errors")
+				assert.Empty(t, errors["code"], "error message is not empty")
 			} else {
 				assert.Error(t, err)
-				assert.Len(t, errors, 1, "got more than one error")
-				assert.Equal(t, "Short code cannot contain special characters", errors[0].Message, "wrong error message")
-				assert.Equal(t, "code", errors[0].Field, "wrong error field")
+				assert.Equal(t, "Short code cannot contain special characters", errors["code"], "wrong error message")
 			}
 		})
 	}

--- a/internal/server/urls.go
+++ b/internal/server/urls.go
@@ -46,8 +46,8 @@ func (s *Server) CreateShortURLHandler(c echo.Context) error {
 			if rep.IsDuplicateKeyError(err) {
 				return c.JSON(http.StatusConflict, map[string]any{
 					"message": "Validation failed",
-					"errors": []appvalidator.ValidationError{
-						{Field: "short_code", Message: "Short code is not available"},
+					"errors": appvalidator.ValidationError{
+						"short_code": "Short code is not available",
 					},
 				})
 			}

--- a/internal/server/urls_test.go
+++ b/internal/server/urls_test.go
@@ -55,12 +55,14 @@ func TestCreateShortURLHandler(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, res.Code)
 
-			var actual repository.Url
-			err = json.NewDecoder(res.Body).Decode(&actual)
-			require.NoError(t, err, "error decoding response body")
-			assert.Len(t, actual.ID, tt.expectedShortUrlLength, fmt.Sprintf("short URL should be %d characters long", tt.expectedShortUrlLength))
-			assert.Equal(t, tt.expectedUrl, actual.LongUrl, "long URL does not match")
-			assert.Equal(t, tt.expectedIsCustom, actual.IsCustom, "isCustom does not match")
+			if tt.expectedStatus == http.StatusCreated {
+				var actual repository.Url
+				err = json.NewDecoder(res.Body).Decode(&actual)
+				require.NoError(t, err, "error decoding response body")
+				assert.Len(t, actual.ID, tt.expectedShortUrlLength, fmt.Sprintf("short URL should be %d characters long", tt.expectedShortUrlLength))
+				assert.Equal(t, tt.expectedUrl, actual.LongUrl, "long URL does not match")
+				assert.Equal(t, tt.expectedIsCustom, actual.IsCustom, "isCustom does not match")
+			}
 		})
 	}
 
@@ -149,12 +151,14 @@ func TestCreateShortURLHandler_CustomShortCode(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, res.Code)
 
-			var actual repository.Url
-			err = json.NewDecoder(res.Body).Decode(&actual)
-			require.NoError(t, err, "error decoding response body")
-			assert.Len(t, actual.ID, tt.expectedShortUrlLen, "incorrect short URL length")
-			assert.Equal(t, tt.expectedUrl, actual.LongUrl, "long URL does not match")
-			assert.Equal(t, tt.expectedIsCustom, actual.IsCustom, "isCustom does not match")
+			if tt.expectedStatus == http.StatusCreated {
+				var actual repository.Url
+				err = json.NewDecoder(res.Body).Decode(&actual)
+				require.NoError(t, err, "error decoding response body")
+				assert.Len(t, actual.ID, tt.expectedShortUrlLen, "incorrect short URL length")
+				assert.Equal(t, tt.expectedUrl, actual.LongUrl, "long URL does not match")
+				assert.Equal(t, tt.expectedIsCustom, actual.IsCustom, "isCustom does not match")
+			}
 		})
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined API validation errors from an array of objects to a single field-to-message map, reducing duplicates and simplifying client parsing.
  - Duplicate short code responses now return errors like {"short_code": "Short code is not available"} instead of a list.

- Tests
  - Updated tests to align with the new error format and to validate response bodies only on successful (201) creations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->