### PR TITLE
SH-62: Add OpenTelemetry Collector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317
 # Trace sampling ratio (0.0 to 1.0). Default: 1.0 (100%)
 # For production, consider 0.1 (10%) to 0.5 (50%)
 OTEL_TRACES_SAMPLER_ARG=1.0
+GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-<zone>.grafana.net/otlp # Grafana Cloud — OTel → Connections > Add new connection > OpenTelemetry (OTLP)
+GRAFANA_CLOUD_INSTANCE_ID=<your_numeric_stack/instance_ID>
+GRAFANA_CLOUD_API_KEY=<grafana_Cloud_API_token_with_MetricsPublisher_LogsPublisher_TracesPublisher_scopes>
 
 # Authentication
 AUTH0_DOMAIN=

--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ Show the current migration version
 just migrate-version
 ```
 
+### Observability
+
+Traces, metrics, and logs are collected via an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) and exported to [Grafana Cloud](https://grafana.com/products/cloud/).
+
+Set the following variables in your `.env` before starting the collector:
+
+| Variable | Where to find it |
+|---|---|
+| `GRAFANA_CLOUD_OTLP_ENDPOINT` | Grafana Cloud → Connections → Add new connection → OpenTelemetry (OTLP) |
+| `GRAFANA_CLOUD_INSTANCE_ID` | Your numeric stack/instance ID on the same page |
+| `GRAFANA_CLOUD_API_KEY` | A Grafana Cloud API token with `MetricsPublisher`, `LogsPublisher`, and `TracesPublisher` scopes |
+
+The collector exposes:
+- **Health check** — `http://localhost:13133`
+- **zPages** (pipeline diagnostics) — `http://localhost:55679/debug/tracez`
+
 ### Quality Control
 
 Audit the application for vulnerabilities, code quality, and dependency issues

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cp .env.example .env
 Run the required services in Docker
 
 ```bash
-docker compose up -d db valkey jaeger
+docker compose up -d db valkey otel-collector
 # or
 just docker-up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,6 @@ services:
         restart: unless-stopped
         ports:
             - "4317:4317" # OTLP gRPC receiver
-            - "4318:4318" # OTLP HTTP receiver
             - "13133:13133" # health_check extension
             - "55679:55679" # ZPages extension; see more here: https://opentelemetry.io/docs/collector/install/docker/#docker-compose
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,15 +68,19 @@ services:
         networks:
             - app_network
     otel-collector:
-        image: otel/opentelemetry-collector:0.148.0
+        image: otel/opentelemetry-collector-contrib:0.149.0
+        command: ["--config=/etc/otel-collector-config.yml"]
         container_name: otel-collector
-        restart: unless-stopped
         ports:
             - "4317:4317" # OTLP gRPC receiver
             - "13133:13133" # health_check extension
             - "55679:55679" # ZPages extension; see more here: https://opentelemetry.io/docs/collector/install/docker/#docker-compose
+        environment:
+            GRAFANA_CLOUD_OTLP_ENDPOINT: ${GRAFANA_CLOUD_OTLP_ENDPOINT}
+            GRAFANA_CLOUD_INSTANCE_ID: ${GRAFANA_CLOUD_INSTANCE_ID}
+            GRAFANA_CLOUD_API_KEY: ${GRAFANA_CLOUD_API_KEY}
         volumes:
-            - ./otel-collector-config.yaml:/etc/otelcol/config.yaml
+            - ./otel-collector-config.yaml:/etc/otel-collector-config.yml
         networks:
             - app_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         networks:
             - app_network
     valkey:
-        image: valkey/valkey:latest
+        image: valkey/valkey:9.1-alpine3.23
         restart: unless-stopped
         ports:
             - "${VALKEY_PORT}:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
         ports:
             - "4317:4317" # OTLP gRPC receiver
             - "4318:4318" # OTLP HTTP receiver
+            - "13133:13133" # health_check extension
             - "55679:55679" # ZPages extension; see more here: https://opentelemetry.io/docs/collector/install/docker/#docker-compose
         volumes:
             - ./otel-collector-config.yaml:/etc/otelcol/config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,17 +67,14 @@ services:
             start_period: 15s
         networks:
             - app_network
-    jaeger:
-        image: cr.jaegertracing.io/jaegertracing/jaeger:latest
-        container_name: jaeger
+    otel-collector:
+        image: otel/opentelemetry-collector:0.148.0
+        container_name: otel-collector
         restart: unless-stopped
-        environment:
-            COLLECTOR_OTLP_ENABLED: "true"
         ports:
-            - "16686:16686"
-            - "4317:4317"
-            - "4318:4318"
-            - "5778:5778"
+            - "4317:4317" # OTLP gRPC
+            - "4318:4318" # OTLP HTTP
+            - "55679:55679" # ZPages
         networks:
             - app_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,11 @@ services:
         container_name: otel-collector
         restart: unless-stopped
         ports:
-            - "4317:4317" # OTLP gRPC
-            - "4318:4318" # OTLP HTTP
-            - "55679:55679" # ZPages
+            - "4317:4317" # OTLP gRPC receiver
+            - "4318:4318" # OTLP HTTP receiver
+            - "55679:55679" # ZPages extension; see more here: https://opentelemetry.io/docs/collector/install/docker/#docker-compose
+        volumes:
+            - ./otel-collector-config.yaml:/etc/otelcol/config.yaml
         networks:
             - app_network
 

--- a/internal/config/otel.go
+++ b/internal/config/otel.go
@@ -12,6 +12,21 @@ type Otel struct {
 }
 
 func loadOtelConfig(logger *slog.Logger) (Otel, error) {
+	// Validate Grafana environment variables
+	// Do not add to the config, they're not needed in the code
+	_, err := getEnv("GRAFANA_CLOUD_OTLP_ENDPOINT")
+	if err != nil {
+		return Otel{}, err
+	}
+	_, err = getEnv("GRAFANA_CLOUD_INSTANCE_ID")
+	if err != nil {
+		return Otel{}, err
+	}
+	_, err = getEnv("GRAFANA_CLOUD_API_KEY")
+	if err != nil {
+		return Otel{}, err
+	}
+
 	tracesEndpoint, err := getEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
 	if err != nil {
 		return Otel{}, err

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ test-cover:
 # run the application services in docker
 [group('dev')]
 docker-up:
-    docker compose up -d db valkey jaeger
+    docker compose up -d db valkey otel-collector
 
 # stop the application services in docker
 [group('dev')]

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -6,6 +6,12 @@ receivers:
             http:
                 endpoint: otel-collector:4318
 
+processors:
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 15
+
 exporters:
     debug:
         verbosity: detailed
@@ -21,10 +27,13 @@ service:
     pipelines:
         traces:
             receivers: [otlp]
+            processors: [memory_limiter]
             exporters: [debug]
         metrics:
             receivers: [otlp]
+            processors: [memory_limiter]
             exporters: [debug]
         logs:
             receivers: [otlp]
+            processors: [memory_limiter]
             exporters: [debug]

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -2,7 +2,7 @@ receivers:
     otlp:
         protocols:
             grpc:
-                endpoint: otel-collector:4317
+                endpoint: 0.0.0.0:4317
 
 processors:
     memory_limiter:
@@ -11,27 +11,33 @@ processors:
         spike_limit_percentage: 15
 
 exporters:
-    debug:
-        verbosity: detailed
+    otlphttp/grafana_cloud:
+        endpoint: ${env:GRAFANA_CLOUD_OTLP_ENDPOINT}
+        auth:
+            authenticator: basicauth/grafana_cloud
 
 extensions:
     health_check:
-        endpoint: otel-collector:13133
+        endpoint: 0.0.0.0:13133
     zpages:
-        endpoint: otel-collector:55679
+        endpoint: 0.0.0.0:55679
+    basicauth/grafana_cloud:
+        client_auth:
+            username: ${env:GRAFANA_CLOUD_INSTANCE_ID}
+            password: ${env:GRAFANA_CLOUD_API_KEY}
 
 service:
-    extensions: [health_check, zpages]
+    extensions: [health_check, zpages, basicauth/grafana_cloud]
     pipelines:
         traces:
             receivers: [otlp]
             processors: [memory_limiter]
-            exporters: [debug]
+            exporters: [otlphttp/grafana_cloud]
         metrics:
             receivers: [otlp]
             processors: [memory_limiter]
-            exporters: [debug]
+            exporters: [otlphttp/grafana_cloud]
         logs:
             receivers: [otlp]
             processors: [memory_limiter]
-            exporters: [debug]
+            exporters: [otlphttp/grafana_cloud]

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -3,8 +3,6 @@ receivers:
         protocols:
             grpc:
                 endpoint: otel-collector:4317
-            http:
-                endpoint: otel-collector:4318
 
 processors:
     memory_limiter:

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,28 @@
+receivers:
+    otlp:
+        protocols:
+            grpc:
+                endpoint: otel-collector:4317
+            http:
+                endpoint: otel-collector:4318
+
+exporters:
+    debug:
+        verbosity: detailed
+
+extensions:
+    zpages:
+        endpoint: otel-collector:55679
+
+service:
+    extensions: [zpages]
+    pipelines:
+        traces:
+            receivers: [otlp]
+            exporters: [debug]
+        metrics:
+            receivers: [otlp]
+            exporters: [debug]
+        logs:
+            receivers: [otlp]
+            exporters: [debug]

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -11,11 +11,13 @@ exporters:
         verbosity: detailed
 
 extensions:
+    health_check:
+        endpoint: otel-collector:13133
     zpages:
         endpoint: otel-collector:55679
 
 service:
-    extensions: [zpages]
+    extensions: [health_check, zpages]
     pipelines:
         traces:
             receivers: [otlp]


### PR DESCRIPTION
## Changes

- Replace Jaeger with OpenTelemetry Collector
- Configure Grafana Cloud exporter in the Collector
  - Only traces for now, next tasks will be adding logs and metrics